### PR TITLE
Removed pathlib deps

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - represent >=1.5.1
     - boltons
     - python-dateutil
-    - pathlib
+    - pathlib # [py<=34]
 
   run:
     - python
@@ -33,7 +33,7 @@ requirements:
     - represent >=1.5.1
     - boltons
     - python-dateutil
-    - pathlib
+    - pathlib # [py<=34]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - represent >=1.5.1
     - boltons
     - python-dateutil
-    - pathlib # [py<=34]
+    - pathlib  # [py<=34]
 
   run:
     - python
@@ -33,7 +33,7 @@ requirements:
     - represent >=1.5.1
     - boltons
     - python-dateutil
-    - pathlib # [py<=34]
+    - pathlib  # [py<=34]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 28ba696fbb537c5a3ce5d7c9bb8eb5cd9cc3ace493d7d9afb299e8c5be4f9fa8 
 
 build:
- number: 0
+ number: 1
  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:


### PR DESCRIPTION
Checklist
* [X] Used a fork of the feedstock to propose changes
* [X] Bumped the build number (if the version is unchanged)

I removed the dependency of pathlib for Python>=3.5. By not using the pathlib module in the standard library, this breaks things in an obscure way in other unrelated packages if this package is installed in the same environment